### PR TITLE
Add react-dom to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "color": "^0.11.1",
     "paper": "^0.9.25",
-    "react": "^15.0.2",
+    "react": "^15.3.1",
+    "react-dom": "^15.3.1",
     "react-router": "^2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
React has been split into [two packages after v0.14](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#major-changes): React and React DOM. This updates the package.json to include react-dom and update the react version.

This looks awesome, by the way! Looking forward to seeing more! 👍 
